### PR TITLE
Push Exceptions into Memory Queue

### DIFF
--- a/Quee.QueueSystem/Memory/InMemoryFaultMessage.cs
+++ b/Quee.QueueSystem/Memory/InMemoryFaultMessage.cs
@@ -1,0 +1,14 @@
+﻿using Quee.Messages;
+
+namespace Quee.Memory;
+
+internal class InMemoryFaultMessage<T>
+    : FaultMessage<T>
+    where T : class
+{
+    public IEnumerable<Exception> SourceExceptions { get; set; } = [];
+    public override IEnumerable<string> Exceptions
+    {
+        get => SourceExceptions.Select(x => $"{x.GetType().Name} - {x.Message}");
+    }
+}

--- a/Quee.QueueSystem/Memory/InMemoryMessage.cs
+++ b/Quee.QueueSystem/Memory/InMemoryMessage.cs
@@ -16,7 +16,7 @@ internal class InMemoryMessage<T>
     /// <summary>
     /// Exceptions encountered while attempting to invoke the consumer across retries
     /// </summary>
-    public List<string> RetryExceptions { get; set; } = [];
+    public List<Exception> RetryExceptions { get; set; } = [];
 
     /// <summary>
     /// Message being sent in the queue

--- a/Quee.QueueSystem/Messages/FaultMessage.cs
+++ b/Quee.QueueSystem/Messages/FaultMessage.cs
@@ -1,7 +1,7 @@
 ﻿namespace Quee.Messages;
 
-public sealed class FaultMessage<T> where T : class
+public class FaultMessage<T> where T : class
 {
-    public required T Payload { get; set; }
-    public IEnumerable<string> Exceptions { get; set; } = [];
+    public virtual required T Payload { get; set; }
+    public virtual IEnumerable<string> Exceptions { get; set; } = [];
 }


### PR DESCRIPTION
To allow for more details when working in the local developer space, exceptions are represented as the whole object in memory for the memory based queue. This is also passed as a custom fault message to allow debugging to see the entire exception that was caught during consumption of a message. 