### PR TITLE
Connection Pooling

### DIFF
--- a/src/Quee.AzureServiceBus/Extensions/RegistrationExtensions.cs
+++ b/src/Quee.AzureServiceBus/Extensions/RegistrationExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
-using Quee.AzureServiceBus.Models;
 using Quee.AzureServiceBus.Services;
 
 #pragma warning disable IDE0130 // Namespace does not match folder structure
@@ -17,9 +16,10 @@ public static class RegistrationExtensions
     public static IServiceCollection QueeWithAzureServiceBus(
         this IServiceCollection services,
         string connectionString,
+        bool allowQueueManagement,
         Action<IAzureServiceBusQueueConfigurator>? configuration = null)
     {
-        IAzureServiceBusQueueConfigurator configurator = new AzureServiceBusQueueConfigurator(services, connectionString);
+        IAzureServiceBusQueueConfigurator configurator = new AzureServiceBusQueueConfigurator(services, connectionString, allowQueueManagement);
         configuration?.Invoke(configurator);
 
         return services;

--- a/src/Quee.AzureServiceBus/Extensions/RegistrationExtensions.cs
+++ b/src/Quee.AzureServiceBus/Extensions/RegistrationExtensions.cs
@@ -16,7 +16,7 @@ public static class RegistrationExtensions
     public static IServiceCollection QueeWithAzureServiceBus(
         this IServiceCollection services,
         string connectionString,
-        bool allowQueueManagement,
+        bool allowQueueManagement = false,
         Action<IAzureServiceBusQueueConfigurator>? configuration = null)
     {
         IAzureServiceBusQueueConfigurator configurator = new AzureServiceBusQueueConfigurator(services, connectionString, allowQueueManagement);

--- a/src/Quee.AzureServiceBus/Interfaces/IAzureServiceBusQueueSenderManager.cs
+++ b/src/Quee.AzureServiceBus/Interfaces/IAzureServiceBusQueueSenderManager.cs
@@ -1,0 +1,9 @@
+﻿using Azure.Messaging.ServiceBus;
+
+namespace Quee.AzureServiceBus.Interfaces
+{
+    internal interface IAzureServiceBusQueueSenderManager
+    {
+        ServiceBusSender CreateSender(string queueName);
+    }
+}

--- a/src/Quee.AzureServiceBus/Quee.AzureServiceBus.csproj
+++ b/src/Quee.AzureServiceBus/Quee.AzureServiceBus.csproj
@@ -10,4 +10,8 @@
     <ProjectReference Include="..\Quee\Quee.csproj" />
   </ItemGroup>
 
+	<ItemGroup>
+		<PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+	</ItemGroup>
+
 </Project>

--- a/src/Quee.AzureServiceBus/Services/AzureServiceBusQueueConfigurator.cs
+++ b/src/Quee.AzureServiceBus/Services/AzureServiceBusQueueConfigurator.cs
@@ -44,7 +44,7 @@ internal sealed class AzureServiceBusQueueConfigurator
         // Register the queue sender manager as a shared resource that allows a single sender to be shared across multiple threads
         services.TryAddSingleton<IAzureServiceBusQueueSenderManager, AzureServiceBusQueueSenderManager>();
 
-        // If the runtime is allow to manage queues, enable the admin client for use
+        // If the runtime is allowed to manage queues, enable the admin client for use
         if (allowAdminManagement)
             services.TryAddSingleton(new ServiceBusAdministrationClient(connectionString));
     }

--- a/src/Quee.AzureServiceBus/Services/AzureServiceBusQueueConfigurator.cs
+++ b/src/Quee.AzureServiceBus/Services/AzureServiceBusQueueConfigurator.cs
@@ -1,5 +1,8 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Quee.AzureServiceBus.Interfaces;
 using System.Collections.Concurrent;
 
 namespace Quee.AzureServiceBus.Services;
@@ -27,13 +30,23 @@ internal sealed class AzureServiceBusQueueConfigurator
     private static string GetTypeKey(IServiceCollection services, Type type)
         => $"{services.GetHashCode()}:{type.FullName}";
 
-    public AzureServiceBusQueueConfigurator(IServiceCollection services, string connectionString)
+    public AzureServiceBusQueueConfigurator(IServiceCollection services, string connectionString, bool allowAdminManagement)
     {
         this.services = services;
         this.connectionString = connectionString;
 
         services.RemoveAll<QueueRetryOptions>();
         services.AddTransient(_ => new QueueRetryOptions() { AllowRetries = true });
+
+        // Register the Client as a singleton for all threads/tasks to share as a common pooled resource
+        services.TryAddSingleton(new ServiceBusClient(connectionString));
+
+        // Register the queue sender manager as a shared resource that allows a single sender to be shared across multiple threads
+        services.TryAddSingleton<IAzureServiceBusQueueSenderManager, AzureServiceBusQueueSenderManager>();
+
+        // If the runtime is allow to manage queues, enable the admin client for use
+        if (allowAdminManagement)
+            services.TryAddSingleton(new ServiceBusAdministrationClient(connectionString));
     }
 
     /// <inheritdoc />
@@ -72,7 +85,6 @@ internal sealed class AzureServiceBusQueueConfigurator
         services.AddHostedService(provider =>
         {
             return new AzureServiceBusQueueConsumer<TMessage>(
-                connectionString,
                 queueName,
                 provider);
         });
@@ -90,7 +102,7 @@ internal sealed class AzureServiceBusQueueConfigurator
         services.AddScoped<IQueueSender<TMessage>>(provider =>
         {
             return new AzureServiceBusQueueSender<TMessage>(
-                connectionString,
+                provider.GetRequiredService<IAzureServiceBusQueueSenderManager>(),
                 queueName,
                 provider.GetRequiredService<QueueRetryOptions>(),
                 provider.GetService<IQueueEventTrackingService>(),

--- a/src/Quee.AzureServiceBus/Services/AzureServiceBusQueueConsumer.cs
+++ b/src/Quee.AzureServiceBus/Services/AzureServiceBusQueueConsumer.cs
@@ -1,8 +1,10 @@
 ﻿using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using Quee.AzureServiceBus.Interfaces;
 using Quee.AzureServiceBus.Models;
 using System.Text;
 
@@ -12,7 +14,6 @@ internal class AzureServiceBusQueueConsumer<TMessage>
     : IHostedService, IAsyncDisposable
     where TMessage : class
 {
-    private readonly string connectionString;
     private readonly string queueName;
     private readonly ConsumerOptions options;
     private readonly ILogger<AzureServiceBusQueueConsumer<TMessage>> logger;
@@ -20,6 +21,7 @@ internal class AzureServiceBusQueueConsumer<TMessage>
     private readonly IQueueEventTrackingService? trackingService;
 
     private readonly ServiceBusClient serviceBusClient;
+    private readonly ServiceBusAdministrationClient? administrationClient;
     private readonly ServiceBusProcessor serviceBusProcessor;
     private readonly ServiceBusSender serviceBusSender;
 
@@ -31,11 +33,9 @@ internal class AzureServiceBusQueueConsumer<TMessage>
     /// <param name="connectionString">Connection string for the Azure Service Bus</param>
     /// <param name="queueName">Queue to work with in the service bus</param>
     public AzureServiceBusQueueConsumer(
-        string connectionString,
         string queueName,
         IServiceProvider serviceProvider)
     {
-        this.connectionString = connectionString;
         this.queueName = queueName;
 
         logger = serviceProvider.GetRequiredService<ILogger<AzureServiceBusQueueConsumer<TMessage>>>();
@@ -48,16 +48,9 @@ internal class AzureServiceBusQueueConsumer<TMessage>
             );
 
         // Build the client for connecting to the service bus
-        serviceBusClient = new ServiceBusClient(connectionString, new ServiceBusClientOptions()
-        {
-            RetryOptions = new()
-            {
-                Delay = TimeSpan.FromSeconds(1),
-                Mode = ServiceBusRetryMode.Exponential,
-                MaxDelay = TimeSpan.FromSeconds(30),
-                MaxRetries = 5
-            }
-        });
+        serviceBusClient = serviceProvider.GetRequiredService<ServiceBusClient>();
+        administrationClient = serviceProvider.GetService<ServiceBusAdministrationClient>();
+        serviceBusSender = serviceProvider.GetRequiredService<IAzureServiceBusQueueSenderManager>().CreateSender(queueName);
 
         // Build the processor with settings for controlling how the processing works
         serviceBusProcessor = serviceBusClient.CreateProcessor(queueName, new ServiceBusProcessorOptions()
@@ -65,7 +58,6 @@ internal class AzureServiceBusQueueConsumer<TMessage>
             MaxConcurrentCalls = options.ConcurrencyLimit,
             PrefetchCount = options.PrefetchLimit
         });
-        serviceBusSender = serviceBusClient.CreateSender(queueName);
     }
 
     /// <inheritdoc />
@@ -80,7 +72,8 @@ internal class AzureServiceBusQueueConsumer<TMessage>
             cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
             // If the queue needs to be checked and the queue doesn't exist (we can't create it when missing), log the message and kill the startup
-            if (!await AzureServiceBusQueueManager.TryCreateQueueIfMissingAsync(connectionString, queueName, cancellationToken))
+            if (administrationClient is not null &&
+                !await AzureServiceBusQueueManager.TryCreateQueueIfMissingAsync(administrationClient, queueName, cancellationToken))
             {
                 logger.LogError("Azure Service Bus Consumer for {QueueName} has failed to start because the queue does not exist and cannot be created.",
                     queueName);

--- a/src/Quee.AzureServiceBus/Services/AzureServiceBusQueueManager.cs
+++ b/src/Quee.AzureServiceBus/Services/AzureServiceBusQueueManager.cs
@@ -13,12 +13,10 @@ internal static class AzureServiceBusQueueManager
     /// <param name="queueName">Name of the queue to look for</param>
     /// <param name="cancellationToken">Process token</param>
     /// <returns>If the queue exists when the method returns</returns>
-    public static async Task<bool> TryCreateQueueIfMissingAsync(string connectionString, string queueName, CancellationToken cancellationToken)
+    public static async Task<bool> TryCreateQueueIfMissingAsync(ServiceBusAdministrationClient client, string queueName, CancellationToken cancellationToken)
     {
         try
         {
-            var client = new ServiceBusAdministrationClient(connectionString);
-
             if (!await client.QueueExistsAsync(queueName, cancellationToken))
             {
                 await client.CreateQueueAsync(queueName, cancellationToken);

--- a/src/Quee.AzureServiceBus/Services/AzureServiceBusQueueSender.cs
+++ b/src/Quee.AzureServiceBus/Services/AzureServiceBusQueueSender.cs
@@ -1,5 +1,6 @@
 ﻿using Azure.Messaging.ServiceBus;
 using Newtonsoft.Json;
+using Quee.AzureServiceBus.Interfaces;
 using Quee.AzureServiceBus.Models;
 using System.Text;
 
@@ -11,20 +12,15 @@ namespace Quee.AzureServiceBus.Services;
 /// </summary>
 /// <typeparam name="TMessage">Message to be sent into the queue</typeparam>
 internal class AzureServiceBusQueueSender<TMessage>
-    : IAsyncDisposable, IQueueSender<TMessage>
+    : IQueueSender<TMessage>
     where TMessage : class
 {
-    private readonly string connectionString;
-    private readonly string queueName;
-    private readonly ServiceBusClient serviceBusClient;
     private readonly ServiceBusSender serviceBusSender;
-    private readonly TimeSpan[] retrySpans;
+    private readonly string queueName;
+    private readonly QueueRetryOptions messageRetryOptions;
+    private readonly IQueueEventTrackingService? queueTrackingService;
+    private readonly TimeSpan[] messageRetryDelays;
 
-    private readonly IQueueEventTrackingService? trackingService;
-    private readonly QueueRetryOptions retryOptions;
-
-    private bool hasCheckedQueueExists = false;
-    private bool queueExists = false;
 
     /// <summary>
     /// Construct a connection to the Service Bus via the provided connection string and for the given queue
@@ -33,20 +29,17 @@ internal class AzureServiceBusQueueSender<TMessage>
     /// <param name="queueName">Name of the queue to submit to</param>
     /// <param name="retrySpans">Timespans between each allowed retry</param>
     internal AzureServiceBusQueueSender(
-        string connectionString,
+        IAzureServiceBusQueueSenderManager queueSenderManager,
         string queueName,
         QueueRetryOptions options,
         IQueueEventTrackingService? trackingService = null,
         params TimeSpan[] retrySpans)
     {
-        this.connectionString = connectionString;
         this.queueName = queueName;
-        this.trackingService = trackingService;
-        this.retryOptions = options;
-        this.retrySpans = retrySpans;
-
-        serviceBusClient = new ServiceBusClient(connectionString);
-        serviceBusSender = serviceBusClient.CreateSender(queueName);
+        serviceBusSender = queueSenderManager.CreateSender(queueName);
+        queueTrackingService = trackingService;
+        messageRetryOptions = options;
+        messageRetryDelays = retrySpans;
     }
 
     /// <summary>
@@ -59,27 +52,13 @@ internal class AzureServiceBusQueueSender<TMessage>
         CancellationToken cancellationToken,
         TimeSpan? initialDelay = null)
     {
-        // Check that the queue exists only once
-        if (!hasCheckedQueueExists)
-        {
-            hasCheckedQueueExists = true;
-            queueExists = await AzureServiceBusQueueManager.TryCreateQueueIfMissingAsync(connectionString, queueName, cancellationToken);
-        }
-
-        // If the queue doesn't exist, we can't send a message to it
-        if (!queueExists)
-        {
-            throw new TransmissionFailureException($"Azure Service Bus Sender for {typeof(TMessage).GetType().Name} cannot send messages to queue {queueName} because " +
-                $"it doesn't exist and the application doesn't have permission to create it.");
-        }
-
         // Wrap the user payload in a retry wrapper, serialize to a string, and then encode for transmission to service bus
         var body = Encoding.UTF8.GetBytes(
             JsonConvert.SerializeObject(
                 new AzureServiceBusMessage<TMessage>()
                 {
                     Payload = message,
-                    RetryDelays = retryOptions.AllowRetries ? retrySpans : []
+                    RetryDelays = messageRetryOptions.AllowRetries ? messageRetryDelays : []
                 }));
 
         var busMessage = new ServiceBusMessage(body);
@@ -88,14 +67,7 @@ internal class AzureServiceBusQueueSender<TMessage>
         if (initialDelay.HasValue)
             busMessage.ScheduledEnqueueTime = DateTime.UtcNow + initialDelay.Value;
 
-        trackingService?.RecordSentMessage(queueName, message);
+        queueTrackingService?.RecordSentMessage(queueName, message);
         await serviceBusSender.SendMessageAsync(busMessage, cancellationToken);
-    }
-
-    /// <inheritdoc />
-    public async ValueTask DisposeAsync()
-    {
-        await serviceBusSender.DisposeAsync().ConfigureAwait(false);
-        await serviceBusClient.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/src/Quee.AzureServiceBus/Services/AzureServiceBusQueueSenderManager.cs
+++ b/src/Quee.AzureServiceBus/Services/AzureServiceBusQueueSenderManager.cs
@@ -1,0 +1,44 @@
+﻿using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
+using Microsoft.Extensions.DependencyInjection;
+using Quee.AzureServiceBus.Interfaces;
+using System.Collections.Concurrent;
+
+namespace Quee.AzureServiceBus.Services;
+
+internal sealed class AzureServiceBusQueueSenderManager(IServiceProvider serviceProvider)
+    : IAsyncDisposable, IAzureServiceBusQueueSenderManager
+{
+    private readonly ServiceBusClient serviceBusClient = serviceProvider.GetRequiredService<ServiceBusClient>();
+    private readonly ServiceBusAdministrationClient? adminClient = serviceProvider.GetService<ServiceBusAdministrationClient>();
+
+    private readonly ConcurrentDictionary<string, ServiceBusSender> queueSenders = [];
+
+    public ServiceBusSender CreateSender(string queueName)
+    {
+        if (adminClient is not null)
+        {
+            if (!AzureServiceBusQueueManager.TryCreateQueueIfMissingAsync(adminClient, queueName, CancellationToken.None).Result)
+                throw new TransmissionFailureException($"Azure Service Bus Sender for queue {queueName} cannot send messages because " +
+                    $"it doesn't exist and the application doesn't have permission to create it.");
+        }
+
+        return queueSenders.GetOrAdd(queueName, serviceBusClient.CreateSender);
+    }
+
+
+    public async ValueTask DisposeAsync()
+    {
+        if (!queueSenders.IsEmpty)
+        {
+            var disposeTasks = queueSenders.Values.Select(sender => sender.DisposeAsync());
+            foreach (var disposeTask in disposeTasks)
+            {
+                await disposeTask.ConfigureAwait(false);
+            }
+            queueSenders.Clear();
+        }
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/Quee.WebApp/Program.cs
+++ b/src/Quee.WebApp/Program.cs
@@ -10,22 +10,22 @@ public class Program
         var builder = WebApplication.CreateBuilder(args);
         builder.Services.AddControllers();
 
-        //builder.Services.QueeWithAzureServiceBus(builder.Configuration["ServiceBusConnectionString"]!, options =>
+        //builder.Services.QueeWithAzureServiceBus(builder.Configuration["ServiceBusConnectionString"]!, true, options =>
         //{
         //    options
         //        .AddSenderAndConsumer<SimpleMessageCommand, SimpleMessageConsumer>(SimpleQueueName, TimeSpan.FromSeconds(1))
         //        .AddSenderAndConsumer<LongRunningTaskCommand, LongRunningTaskConsumer>(LongRunningQueueName, TimeSpan.FromSeconds(1));
-            
+
         //    options
         //        .AddQueueConsumerOptions(SimpleQueueName, new ConsumerOptions()
         //        {
         //            PrefetchLimit = 10,
-        //            ConcurrencyLimit = 1,
+        //            ConcurrencyLimit = 10,
         //        })
         //        .AddQueueConsumerOptions(LongRunningQueueName, new ConsumerOptions()
         //        {
         //            PrefetchLimit = 10,
-        //            ConcurrencyLimit = 1,
+        //            ConcurrencyLimit = 10,
         //        });
         //});
 
@@ -33,31 +33,33 @@ public class Program
         app.UseHttpsRedirection();
         //app.MapPost(
         //    "/simple-message", async (
-        //    [FromServices] Quee.IQueueSender<SimpleMessageCommand> sender,
+        //    [FromServices] IQueueSender<SimpleMessageCommand> sender,
         //    [FromServices] ILogger<SimpleMessageCommand> logger,
         //    [FromQuery] int messageCount,
         //    [FromQuery] string message,
         //    CancellationToken cancellationToken) =>
         //{
-        //    for (int i = 0; i < messageCount; i++)
-        //    {
-        //        logger.LogInformation("Sent simple message to quee");
-        //        await sender.SendMessageAsync(new SimpleMessageCommand(Guid.NewGuid(), message), cancellationToken);
-        //    }
+        //    var messageTasks = Enumerable.Range(0, messageCount)
+        //        .Select(x => sender.SendMessageAsync(new SimpleMessageCommand(Guid.NewGuid(), message), cancellationToken))
+        //        .ToList();
+
+        //    await Task.WhenAll(messageTasks);
+        //    return TypedResults.Ok();
         //});
         //app.MapPost(
         //    "/long-running", async (
-        //    [FromServices] Quee.IQueueSender<LongRunningTaskCommand> sender,
+        //    [FromServices] IQueueSender<LongRunningTaskCommand> sender,
         //    [FromServices] ILogger<LongRunningTaskCommand> logger,
         //    [FromQuery] int messageCount,
         //    [FromQuery] int delay,
         //    CancellationToken cancellationToken) =>
         //    {
-        //        for (int i = 0; i < messageCount; i++)
-        //        {
-        //            logger.LogInformation("Sent long task to quee");
-        //            await sender.SendMessageAsync(new LongRunningTaskCommand(delay), cancellationToken);
-        //        }
+        //        var messageTasks = Enumerable.Range(0, messageCount)
+        //        .Select(x => sender.SendMessageAsync(new LongRunningTaskCommand(delay), cancellationToken))
+        //        .ToList();
+
+        //        await Task.WhenAll(messageTasks);
+        //        return TypedResults.Ok();
         //    });
         app.MapGet("/", () => TypedResults.Ok("Running"));
         app.Run();

--- a/src/Quee/InMemoryProvider/Services/InMemoryQueueConfigurator.cs
+++ b/src/Quee/InMemoryProvider/Services/InMemoryQueueConfigurator.cs
@@ -10,11 +10,21 @@ namespace Quee;
 /// <summary>
 /// Handles configuration for the in-memory queue based services
 /// </summary>
-internal class InMemoryQueueConfigurator(IServiceCollection services)
+internal class InMemoryQueueConfigurator
         : IInMemoryQueueConfigurator
 {
+    private readonly IServiceCollection services;
+
     private readonly bool allowRetries = true;
     private readonly ConcurrentDictionary<string, byte> registrationTracker = new();
+
+    public InMemoryQueueConfigurator(IServiceCollection services)
+    {
+        this.services = services;
+
+        services.RemoveAll<QueueRetryOptions>();
+        services.AddTransient(_ => new QueueRetryOptions() { AllowRetries = true });
+    }
 
     /// <summary>
     /// Takes the DI Container instance and combines it with the type information of the provided type. 
@@ -50,7 +60,7 @@ internal class InMemoryQueueConfigurator(IServiceCollection services)
             return this;
 
         AddChannelForMessage<TMessage>();
-        
+
         services.TryAddTransient<IQueueSender<TMessage>>((provider) =>
         {
             return new InMemoryQueueSender<TMessage>(
@@ -58,7 +68,7 @@ internal class InMemoryQueueConfigurator(IServiceCollection services)
                 provider.GetRequiredService<QueueRetryOptions>(),
                 allowRetries ? retries : [], // Optionally disable the retries provided depending on the disable invocation
                 provider.GetRequiredService<Channel<InMemoryMessage<TMessage>>>(),
-                provider.GetService<IQueueEventTrackingService>()); 
+                provider.GetService<IQueueEventTrackingService>());
         });
 
         return this;
@@ -103,7 +113,7 @@ internal class InMemoryQueueConfigurator(IServiceCollection services)
     /// Registers a <see cref="Channel"/> for the message type <typeparamref name="TMessage"/> to use when reading or writing
     /// </summary>
     /// <typeparam name="TMessage">Type of message for the channel to send/receive</typeparam>
-    private void AddChannelForMessage<TMessage>() 
+    private void AddChannelForMessage<TMessage>()
         where TMessage : class
     {
         // Adds the singleton for the communication channel once to the DI container

--- a/src/Quee/Quee.csproj
+++ b/src/Quee/Quee.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />


### PR DESCRIPTION
Discovered an issue where the service bus has a max of 1000 connections at any given time. Because the implementation spun up a new connection for each sender/consumer this would cause a resource exhaustion when deployed at scale. This PR pools the senders and the client into singletons to allow multiple tasks to share a single connection to prevent this issue.